### PR TITLE
Do not include JS/CSS client libraries twice if the same library is requested multiple times within one request.

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,8 +24,9 @@
   <body>
 
     <release version="1.4.0" date="not released">
-      <action type="update" dev="sseifert" issue="5">
+      <action type="add" dev="sseifert" issue="5">
         Do not include JS/CSS client libraries twice if the same library is requested multiple times within one request.
+        This new behavior can be disabled by setting allowMultipleIncludes=true.
       </action>
       <action type="fix" dev="sseifert" issue="6">
         Ensure request context path is added to client library URLs.

--- a/changes.xml
+++ b/changes.xml
@@ -23,7 +23,13 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
-    <release version="1.3.2" date="not released">
+    <release version="1.4.0" date="not released">
+      <action type="update" dev="sseifert">
+        Do not include JS/CSS client libraries twice if the same library is requested multiple times within one request.
+      </action>
+      <action type="update" dev="sseifert">
+        Ensure request context path is added to client library URLs.
+      </action>
       <action type="update" dev="sseifert">
         Switch to AEM 6.5.17 as minimum version.
       </action>

--- a/changes.xml
+++ b/changes.xml
@@ -24,10 +24,10 @@
   <body>
 
     <release version="1.4.0" date="not released">
-      <action type="update" dev="sseifert">
+      <action type="update" dev="sseifert" issue="5">
         Do not include JS/CSS client libraries twice if the same library is requested multiple times within one request.
       </action>
-      <action type="update" dev="sseifert">
+      <action type="update" dev="sseifert" issue="5">
         Ensure request context path is added to client library URLs.
       </action>
       <action type="update" dev="sseifert">

--- a/src/main/java/io/wcm/wcm/ui/clientlibs/components/CSSInclude.java
+++ b/src/main/java/io/wcm/wcm/ui/clientlibs/components/CSSInclude.java
@@ -65,6 +65,8 @@ public class CSSInclude {
   @RequestAttribute(injectionStrategy = InjectionStrategy.OPTIONAL)
   private String rel;
   @RequestAttribute(injectionStrategy = InjectionStrategy.OPTIONAL)
+  private String allowMultipleIncludes;
+  @RequestAttribute(injectionStrategy = InjectionStrategy.OPTIONAL)
   private Object customAttributes;
 
   private String include;
@@ -111,13 +113,14 @@ public class CSSInclude {
    */
   private @NotNull String buildIncludeString(@NotNull List<String> libraryPaths, @NotNull Map<String, String> attrs,
       @NotNull Map<String, String> customAttrs) {
-    return new RequestIncludedLibraries(request).buildMarkupIgnoringDuplicateLibraries(libraryPaths, libraryPath -> {
-      HtmlTagBuilder builder = new HtmlTagBuilder("link", false, xssApi);
-      builder.setAttrs(attrs);
-      builder.setAttrs(customAttrs);
-      builder.setAttr("href", request.getContextPath() + libraryPath);
-      return builder;
-    });
+    return new RequestIncludedLibraries(request, allowMultipleIncludes)
+        .buildMarkupIgnoringDuplicateLibraries(libraryPaths, libraryPath -> {
+          HtmlTagBuilder builder = new HtmlTagBuilder("link", false, xssApi);
+          builder.setAttrs(attrs);
+          builder.setAttrs(customAttrs);
+          builder.setAttr("href", request.getContextPath() + libraryPath);
+          return builder;
+        });
   }
 
   /**

--- a/src/main/java/io/wcm/wcm/ui/clientlibs/components/CSSInclude.java
+++ b/src/main/java/io/wcm/wcm/ui/clientlibs/components/CSSInclude.java
@@ -52,6 +52,8 @@ public class CSSInclude {
       "prefetch", "preload");
 
   @SlingObject
+  private SlingHttpServletRequest request;
+  @SlingObject
   private ResourceResolver resourceResolver;
   @OSGiService
   private HtmlLibraryManager htmlLibraryManager;
@@ -109,13 +111,20 @@ public class CSSInclude {
    */
   private @NotNull String buildIncludeString(@NotNull List<String> libraryPaths, @NotNull Map<String, String> attrs,
       @NotNull Map<String, String> customAttrs) {
+    RequestIncludedLibraries includedLibraries = new RequestIncludedLibraries(request);
     StringBuilder markup = new StringBuilder();
     for (String libraryPath : libraryPaths) {
+      // ignore libraries that are already included
+      if (includedLibraries.isInlucded(libraryPath)) {
+        continue;
+      }
       HtmlTagBuilder builder = new HtmlTagBuilder("link", false, xssApi);
       builder.setAttrs(attrs);
       builder.setAttrs(customAttrs);
-      builder.setAttr("href", libraryPath);
+      builder.setAttr("href", request.getContextPath() + libraryPath);
       markup.append(builder.build());
+      // mark library as included
+      includedLibraries.storeIncluded(libraryPath);
     }
     return markup.toString();
   }

--- a/src/main/java/io/wcm/wcm/ui/clientlibs/components/CSSInclude.java
+++ b/src/main/java/io/wcm/wcm/ui/clientlibs/components/CSSInclude.java
@@ -65,7 +65,7 @@ public class CSSInclude {
   @RequestAttribute(injectionStrategy = InjectionStrategy.OPTIONAL)
   private String rel;
   @RequestAttribute(injectionStrategy = InjectionStrategy.OPTIONAL)
-  private String allowMultipleIncludes;
+  private Object allowMultipleIncludes;
   @RequestAttribute(injectionStrategy = InjectionStrategy.OPTIONAL)
   private Object customAttributes;
 

--- a/src/main/java/io/wcm/wcm/ui/clientlibs/components/CSSInclude.java
+++ b/src/main/java/io/wcm/wcm/ui/clientlibs/components/CSSInclude.java
@@ -111,22 +111,13 @@ public class CSSInclude {
    */
   private @NotNull String buildIncludeString(@NotNull List<String> libraryPaths, @NotNull Map<String, String> attrs,
       @NotNull Map<String, String> customAttrs) {
-    RequestIncludedLibraries includedLibraries = new RequestIncludedLibraries(request);
-    StringBuilder markup = new StringBuilder();
-    for (String libraryPath : libraryPaths) {
-      // ignore libraries that are already included
-      if (includedLibraries.isInlucded(libraryPath)) {
-        continue;
-      }
+    return new RequestIncludedLibraries(request).buildMarkupIgnoringDuplicateLibraries(libraryPaths, libraryPath -> {
       HtmlTagBuilder builder = new HtmlTagBuilder("link", false, xssApi);
       builder.setAttrs(attrs);
       builder.setAttrs(customAttrs);
       builder.setAttr("href", request.getContextPath() + libraryPath);
-      markup.append(builder.build());
-      // mark library as included
-      includedLibraries.storeIncluded(libraryPath);
-    }
-    return markup.toString();
+      return builder;
+    });
   }
 
   /**

--- a/src/main/java/io/wcm/wcm/ui/clientlibs/components/IncludeUtil.java
+++ b/src/main/java/io/wcm/wcm/ui/clientlibs/components/IncludeUtil.java
@@ -97,7 +97,7 @@ final class IncludeUtil {
       path = "/etc.clientlibs" + path.substring(5);
     }
     else if (resourceResolver.getResource(library.getPath()) == null) {
-      // current render resourcer resolver has no access to the client library - ignore it
+      // current render resource resolver has no access to the client library - ignore it
       path = null;
     }
     return path;

--- a/src/main/java/io/wcm/wcm/ui/clientlibs/components/JSInclude.java
+++ b/src/main/java/io/wcm/wcm/ui/clientlibs/components/JSInclude.java
@@ -58,6 +58,8 @@ public class JSInclude {
       "text/javascript", "module");
 
   @SlingObject
+  private SlingHttpServletRequest request;
+  @SlingObject
   private ResourceResolver resourceResolver;
   @OSGiService
   private HtmlLibraryManager htmlLibraryManager;
@@ -145,13 +147,20 @@ public class JSInclude {
    */
   private @NotNull String buildIncludeString(@NotNull List<String> libraryPaths, @NotNull Map<String, String> attrs,
       @NotNull Map<String, String> customAttrs) {
+    RequestIncludedLibraries includedLibraries = new RequestIncludedLibraries(request);
     StringBuilder markup = new StringBuilder();
     for (String libraryPath : libraryPaths) {
+      // ignore libraries that are already included
+      if (includedLibraries.isInlucded(libraryPath)) {
+        continue;
+      }
       HtmlTagBuilder builder = new HtmlTagBuilder("script", true, xssApi);
       builder.setAttrs(attrs);
       builder.setAttrs(customAttrs);
-      builder.setAttr("src", libraryPath);
+      builder.setAttr("src", request.getContextPath() + libraryPath);
       markup.append(builder.build());
+      // mark library as included
+      includedLibraries.storeIncluded(libraryPath);
     }
     return markup.toString();
   }

--- a/src/main/java/io/wcm/wcm/ui/clientlibs/components/JSInclude.java
+++ b/src/main/java/io/wcm/wcm/ui/clientlibs/components/JSInclude.java
@@ -85,7 +85,7 @@ public class JSInclude {
   @RequestAttribute(injectionStrategy = InjectionStrategy.OPTIONAL)
   private String type;
   @RequestAttribute(injectionStrategy = InjectionStrategy.OPTIONAL)
-  private String allowMultipleIncludes;
+  private Object allowMultipleIncludes;
   @RequestAttribute(injectionStrategy = InjectionStrategy.OPTIONAL)
   private Object customAttributes;
 

--- a/src/main/java/io/wcm/wcm/ui/clientlibs/components/JSInclude.java
+++ b/src/main/java/io/wcm/wcm/ui/clientlibs/components/JSInclude.java
@@ -85,6 +85,8 @@ public class JSInclude {
   @RequestAttribute(injectionStrategy = InjectionStrategy.OPTIONAL)
   private String type;
   @RequestAttribute(injectionStrategy = InjectionStrategy.OPTIONAL)
+  private String allowMultipleIncludes;
+  @RequestAttribute(injectionStrategy = InjectionStrategy.OPTIONAL)
   private Object customAttributes;
 
   private String include;
@@ -147,13 +149,14 @@ public class JSInclude {
    */
   private @NotNull String buildIncludeString(@NotNull List<String> libraryPaths, @NotNull Map<String, String> attrs,
       @NotNull Map<String, String> customAttrs) {
-    return new RequestIncludedLibraries(request).buildMarkupIgnoringDuplicateLibraries(libraryPaths, libraryPath -> {
-      HtmlTagBuilder builder = new HtmlTagBuilder("script", true, xssApi);
-      builder.setAttrs(attrs);
-      builder.setAttrs(customAttrs);
-      builder.setAttr("src", request.getContextPath() + libraryPath);
-      return builder;
-    });
+    return new RequestIncludedLibraries(request, allowMultipleIncludes)
+        .buildMarkupIgnoringDuplicateLibraries(libraryPaths, libraryPath -> {
+          HtmlTagBuilder builder = new HtmlTagBuilder("script", true, xssApi);
+          builder.setAttrs(attrs);
+          builder.setAttrs(customAttrs);
+          builder.setAttr("src", request.getContextPath() + libraryPath);
+          return builder;
+        });
   }
 
   /**

--- a/src/main/java/io/wcm/wcm/ui/clientlibs/components/JSInclude.java
+++ b/src/main/java/io/wcm/wcm/ui/clientlibs/components/JSInclude.java
@@ -147,22 +147,13 @@ public class JSInclude {
    */
   private @NotNull String buildIncludeString(@NotNull List<String> libraryPaths, @NotNull Map<String, String> attrs,
       @NotNull Map<String, String> customAttrs) {
-    RequestIncludedLibraries includedLibraries = new RequestIncludedLibraries(request);
-    StringBuilder markup = new StringBuilder();
-    for (String libraryPath : libraryPaths) {
-      // ignore libraries that are already included
-      if (includedLibraries.isInlucded(libraryPath)) {
-        continue;
-      }
+    return new RequestIncludedLibraries(request).buildMarkupIgnoringDuplicateLibraries(libraryPaths, libraryPath -> {
       HtmlTagBuilder builder = new HtmlTagBuilder("script", true, xssApi);
       builder.setAttrs(attrs);
       builder.setAttrs(customAttrs);
       builder.setAttr("src", request.getContextPath() + libraryPath);
-      markup.append(builder.build());
-      // mark library as included
-      includedLibraries.storeIncluded(libraryPath);
-    }
-    return markup.toString();
+      return builder;
+    });
   }
 
   /**

--- a/src/main/java/io/wcm/wcm/ui/clientlibs/components/RequestIncludedLibraries.java
+++ b/src/main/java/io/wcm/wcm/ui/clientlibs/components/RequestIncludedLibraries.java
@@ -1,0 +1,74 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2024 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.wcm.ui.clientlibs.components;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+
+import com.adobe.granite.ui.clientlibs.HtmlLibraryManager;
+import com.drew.lang.annotations.NotNull;
+
+class RequestIncludedLibraries {
+
+  /**
+   * Request attributes that is also used by Granite UI clientlib manager to store the (raw) library
+   * paths that are already included in the current request.
+   */
+  private static final String RA_INCLUDED_LIBRARY_PATHS = HtmlLibraryManager.class.getName() + ".included";
+
+  private final SlingHttpServletRequest request;
+
+  RequestIncludedLibraries(SlingHttpServletRequest request) {
+    this.request = request;
+  }
+
+  /**
+   * Gets set of library paths from request attribute. If not set, attribute is initialized with an empty set.
+   * @return Set of library paths attached to current request
+   */
+  @SuppressWarnings("unchecked")
+  private @NotNull Set<String> getLibaryPathsSetFromRequest() {
+    Set<String> libraryPaths = (Set<String>)request.getAttribute(RA_INCLUDED_LIBRARY_PATHS);
+    if (libraryPaths == null) {
+      libraryPaths = new HashSet<>();
+      request.setAttribute(RA_INCLUDED_LIBRARY_PATHS, libraryPaths);
+    }
+    return libraryPaths;
+  }
+
+  /**
+   * @param libraryPath Library path
+   * @return true if given library was already included in current request.
+   */
+  boolean isInlucded(@NotNull String libraryPath) {
+    return getLibaryPathsSetFromRequest().contains(libraryPath);
+  }
+
+  /**
+   * Store library path as included in current request.
+   * @param libraryPath Library path
+   */
+  void storeIncluded(@NotNull String libraryPath) {
+    getLibaryPathsSetFromRequest().add(libraryPath);
+  }
+
+}

--- a/src/main/java/io/wcm/wcm/ui/clientlibs/components/RequestIncludedLibraries.java
+++ b/src/main/java/io/wcm/wcm/ui/clientlibs/components/RequestIncludedLibraries.java
@@ -20,7 +20,9 @@
 package io.wcm.wcm.ui.clientlibs.components;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 
 import org.apache.sling.api.SlingHttpServletRequest;
 
@@ -69,6 +71,29 @@ class RequestIncludedLibraries {
    */
   void storeIncluded(@NotNull String libraryPath) {
     getLibaryPathsSetFromRequest().add(libraryPath);
+  }
+
+  /**
+   * Builds the markup for all given HTML libraries that are not already included in the current request.
+   * @param libraryPaths Library paths
+   * @param htmlTagBuilderFactory Factory to create HTML tag builders
+   * @return Markup
+   */
+  String buildMarkupIgnoringDuplicateLibraries(@NotNull List<String> libraryPaths,
+      @NotNull Function<String, HtmlTagBuilder> htmlTagBuilderFactory) {
+    RequestIncludedLibraries includedLibraries = new RequestIncludedLibraries(request);
+    StringBuilder markup = new StringBuilder();
+    for (String libraryPath : libraryPaths) {
+      // ignore libraries that are already included
+      if (includedLibraries.isInlucded(libraryPath)) {
+        continue;
+      }
+      // build markup for library
+      markup.append(htmlTagBuilderFactory.apply(libraryPath).build());
+      // mark library as included
+      includedLibraries.storeIncluded(libraryPath);
+    }
+    return markup.toString();
   }
 
 }

--- a/src/main/java/io/wcm/wcm/ui/clientlibs/components/RequestIncludedLibraries.java
+++ b/src/main/java/io/wcm/wcm/ui/clientlibs/components/RequestIncludedLibraries.java
@@ -24,7 +24,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
+import org.jetbrains.annotations.Nullable;
 
 import com.adobe.granite.ui.clientlibs.HtmlLibraryManager;
 import com.drew.lang.annotations.NotNull;
@@ -38,9 +40,12 @@ class RequestIncludedLibraries {
   private static final String RA_INCLUDED_LIBRARY_PATHS = HtmlLibraryManager.class.getName() + ".included";
 
   private final SlingHttpServletRequest request;
+  private final boolean allowMultipleIncludes;
 
-  RequestIncludedLibraries(SlingHttpServletRequest request) {
+  RequestIncludedLibraries(@NotNull SlingHttpServletRequest request,
+      @Nullable String allowMultipleIncludes) {
     this.request = request;
+    this.allowMultipleIncludes = BooleanUtils.toBoolean(allowMultipleIncludes);
   }
 
   /**
@@ -81,17 +86,16 @@ class RequestIncludedLibraries {
    */
   String buildMarkupIgnoringDuplicateLibraries(@NotNull List<String> libraryPaths,
       @NotNull Function<String, HtmlTagBuilder> htmlTagBuilderFactory) {
-    RequestIncludedLibraries includedLibraries = new RequestIncludedLibraries(request);
     StringBuilder markup = new StringBuilder();
     for (String libraryPath : libraryPaths) {
       // ignore libraries that are already included
-      if (includedLibraries.isInlucded(libraryPath)) {
+      if (!allowMultipleIncludes && isInlucded(libraryPath)) {
         continue;
       }
       // build markup for library
       markup.append(htmlTagBuilderFactory.apply(libraryPath).build());
       // mark library as included
-      includedLibraries.storeIncluded(libraryPath);
+      storeIncluded(libraryPath);
     }
     return markup.toString();
   }

--- a/src/main/java/io/wcm/wcm/ui/clientlibs/components/RequestIncludedLibraries.java
+++ b/src/main/java/io/wcm/wcm/ui/clientlibs/components/RequestIncludedLibraries.java
@@ -43,9 +43,9 @@ class RequestIncludedLibraries {
   private final boolean allowMultipleIncludes;
 
   RequestIncludedLibraries(@NotNull SlingHttpServletRequest request,
-      @Nullable String allowMultipleIncludes) {
+      @Nullable Object allowMultipleIncludes) {
     this.request = request;
-    this.allowMultipleIncludes = BooleanUtils.toBoolean(allowMultipleIncludes);
+    this.allowMultipleIncludes = toBoolean(allowMultipleIncludes);
   }
 
   /**
@@ -98,6 +98,16 @@ class RequestIncludedLibraries {
       storeIncluded(libraryPath);
     }
     return markup.toString();
+  }
+
+  private static boolean toBoolean(Object value) {
+    if (value instanceof Boolean) {
+      return (Boolean)value;
+    }
+    else if (value instanceof String) {
+      return BooleanUtils.toBoolean((String)value);
+    }
+    return false;
   }
 
 }

--- a/src/main/webapp/app-root/sightly/templates/clientlib.html
+++ b/src/main/webapp/app-root/sightly/templates/clientlib.html
@@ -9,14 +9,16 @@
      * @param nonce see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-nonce
      * @param referrerpolicy see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-referrerpolicy
      * @param type see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-type
+     * @param allowMultipleIncludes If set to true, duplicate inclusions of this client library in a single request are not eliminated.
      * @param customAttributes List of custom attributes, each list item in syntax 'attr=value' or just 'attr'
      */-->
 <template data-sly-template.js="${@ categories, async, crossorigin, defer, integrity,
-    nomodule, nonce, referrerpolicy, type, customAttributes}">
+    nomodule, nonce, referrerpolicy, type, allowMultipleIncludes, customAttributes}">
   <sly data-sly-test="${request.getResourceResolver}"
       data-sly-use.clientlib="${'io.wcm.wcm.ui.clientlibs.components.JSInclude' @
       categories=categories, async=async, crossorigin=crossorigin, defer=defer, integrity=integrity,
-      nomodule=nomodule, nonce=nonce, referrerpolicy=referrerpolicy, type=type, customAttributes=customAttributes}">
+      nomodule=nomodule, nonce=nonce, referrerpolicy=referrerpolicy, type=type,
+      allowMultipleIncludes=allowMultipleIncludes, customAttributes=customAttributes}">
 ${clientlib.include @ context='unsafe'}
   </sly>
 </template>
@@ -25,12 +27,14 @@ ${clientlib.include @ context='unsafe'}
      * Template used for including CSS client libraries.
      * @param categories Client Library categories
      * @param rel prefetch|preload see https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel
+     * @param allowMultipleIncludes If set to true, duplicate inclusions of this client library in a single request are not eliminated.
      * @param customAttributes List of custom attributes, each list item in syntax 'attr=value' or just 'attr'
      */-->
-<template data-sly-template.css="${@ categories, customAttributes}">
+<template data-sly-template.css="${@ categories, allowMultipleIncludes, customAttributes}">
   <sly data-sly-test="${request.getResourceResolver}"
       data-sly-use.clientlib="${'io.wcm.wcm.ui.clientlibs.components.CSSInclude' @
-      categories=categories, rel=rel, customAttributes=customAttributes}">
+      categories=categories, rel=rel,
+      allowMultipleIncludes=allowMultipleIncludes, customAttributes=customAttributes}">
 ${clientlib.include @ context='unsafe'}
   </sly>
 </template>

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -22,7 +22,7 @@ Extensions for AEM HTML client libraries.
 
 |WCM Clientlibs UI Extensions version |AEM version supported
 |-------------------------------------|----------------------
-|1.3.2 or higher                      |AEM 6.5.17+, AEMaaCS
+|1.4.0 or higher                      |AEM 6.5.17+, AEMaaCS
 |1.3.0                                |AEM 6.5.7+, AEMaaCS
 |1.2.x                                |AEM 6.4+, AEMaaCS
 |1.1.x                                |AEM 6.3+

--- a/src/site/markdown/usage.md
+++ b/src/site/markdown/usage.md
@@ -27,6 +27,7 @@ The following advanced script tag attributes are supported:
 * `nonce` = {string}
 * `referrerpolicy` = no-referrer | no-referrer-when-downgrade | origin | origin-when-cross-origin | same-origin | strict-origin | strict-origin-when-cross-origin | unsafe-url
 * `type` = module | text/javascript
+* `allowMultipleIncludes` - by default, multiple includes of the same script in a single request are eliminated. If setting this property to `true`, they are included multiple times if requested.
 * `customAttributes` - set arbitrary HTML attributes, e.g. `customAttributes=['attr1=value 1','data-attr2=5','attr3']`
 
 See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#Attributes for a full documentation of this attributes.
@@ -44,4 +45,5 @@ Include CSS without special attributes:
 The following advanced link tag attributes are supported:
 
 * `rel` = prefetch | preload (if not given, `rel="stylesheet" type="text/css"` is set)
+* `allowMultipleIncludes` - by default, multiple includes of the same script in a single request are eliminated. If setting this property to `true`, they are included multiple times if requested.
 * `customAttributes` - set arbitrary HTML attributes, e.g. `customAttributes=['attr1=value 1','data-attr2=5','attr3']`

--- a/src/test/java/io/wcm/wcm/ui/clientlibs/components/AbstractIncludeTest.java
+++ b/src/test/java/io/wcm/wcm/ui/clientlibs/components/AbstractIncludeTest.java
@@ -28,9 +28,11 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.apache.sling.xss.XSSAPI;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.provider.Arguments;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -97,6 +99,12 @@ abstract class AbstractIncludeTest {
     when(clientlib.allowProxy()).thenReturn(allowProxy);
     context.create().resource(path);
     return clientlib;
+  }
+
+  static Stream<Arguments> booleanTrueVariants() {
+    return Stream.of(
+        Arguments.of(true),
+        Arguments.of("true"));
   }
 
 }

--- a/src/test/java/io/wcm/wcm/ui/clientlibs/components/CSSIncludeTest.java
+++ b/src/test/java/io/wcm/wcm/ui/clientlibs/components/CSSIncludeTest.java
@@ -48,6 +48,15 @@ class CSSIncludeTest extends AbstractIncludeTest {
         underTest.getInclude());
   }
 
+  @Test
+  void testSingle_ContextPath() {
+    context.request().setContextPath("/mycontext");
+    context.request().setAttribute("categories", CATEGORY_SINGLE);
+    CSSInclude underTest = AdaptTo.notNull(context.request(), CSSInclude.class);
+    assertEquals("<link href=\"/mycontext/etc/clientlibs/app1/clientlib1.min.css\" rel=\"stylesheet\" type=\"text/css\">\n",
+        underTest.getInclude());
+  }
+
   @ParameterizedTest
   @ValueSource(strings = { "preload", "prefetch" })
   void testSingle_rel_valid(String validRelParameter) {
@@ -116,6 +125,27 @@ class CSSIncludeTest extends AbstractIncludeTest {
     context.resourceResolver().delete(context.resourceResolver().getResource("/etc/clientlibs/app1/clientlib1"));
     CSSInclude underTest = AdaptTo.notNull(context.request(), CSSInclude.class);
     assertNull(underTest.getInclude());
+  }
+
+  @Test
+  void testMultiIgnoreDuplicates() {
+    context.request().setAttribute("categories", CATEGORIES_MULTIPLE);
+    CSSInclude underTest = AdaptTo.notNull(context.request(), CSSInclude.class);
+    assertEquals("<link href=\"/etc/clientlibs/app1/clientlib3.min.css\" rel=\"stylesheet\" type=\"text/css\">\n"
+        + "<link href=\"/etc.clientlibs/app1/clientlibs/clientlib4_proxy.min.css\" rel=\"stylesheet\" type=\"text/css\">\n"
+        + "<link href=\"/etc.clientlibs/app1/clientlibs/clientlib5_proxy.min.css\" rel=\"stylesheet\" type=\"text/css\">\n",
+        underTest.getInclude());
+
+    // include again - should not include anything
+    context.request().setAttribute("categories", CATEGORIES_MULTIPLE);
+    underTest = AdaptTo.notNull(context.request(), CSSInclude.class);
+    assertEquals("", underTest.getInclude());
+
+    // include something different - should include again
+    context.request().setAttribute("categories", CATEGORY_SINGLE);
+    underTest = AdaptTo.notNull(context.request(), CSSInclude.class);
+    assertEquals("<link href=\"/etc/clientlibs/app1/clientlib1.min.css\" rel=\"stylesheet\" type=\"text/css\">\n",
+        underTest.getInclude());
   }
 
 }

--- a/src/test/java/io/wcm/wcm/ui/clientlibs/components/CSSIncludeTest.java
+++ b/src/test/java/io/wcm/wcm/ui/clientlibs/components/CSSIncludeTest.java
@@ -148,4 +148,23 @@ class CSSIncludeTest extends AbstractIncludeTest {
         underTest.getInclude());
   }
 
+  @Test
+  void testMultiAllowDuplicates() {
+    final String expectedInclude = "<link href=\"/etc/clientlibs/app1/clientlib3.min.css\" rel=\"stylesheet\" type=\"text/css\">\n"
+        + "<link href=\"/etc.clientlibs/app1/clientlibs/clientlib4_proxy.min.css\" rel=\"stylesheet\" type=\"text/css\">\n"
+        + "<link href=\"/etc.clientlibs/app1/clientlibs/clientlib5_proxy.min.css\" rel=\"stylesheet\" type=\"text/css\">\n";
+
+    context.request().setAttribute("categories", CATEGORIES_MULTIPLE);
+    context.request().setAttribute("allowMultipleIncludes", "true");
+    CSSInclude underTest = AdaptTo.notNull(context.request(), CSSInclude.class);
+    assertEquals(expectedInclude,
+        underTest.getInclude());
+
+    // include again - should be included again (no duplicates removed)
+    context.request().setAttribute("categories", CATEGORIES_MULTIPLE);
+    context.request().setAttribute("allowMultipleIncludes", "true");
+    underTest = AdaptTo.notNull(context.request(), CSSInclude.class);
+    assertEquals(expectedInclude, underTest.getInclude());
+  }
+
 }

--- a/src/test/java/io/wcm/wcm/ui/clientlibs/components/CSSIncludeTest.java
+++ b/src/test/java/io/wcm/wcm/ui/clientlibs/components/CSSIncludeTest.java
@@ -27,6 +27,7 @@ import org.apache.sling.api.resource.PersistenceException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -148,21 +149,22 @@ class CSSIncludeTest extends AbstractIncludeTest {
         underTest.getInclude());
   }
 
-  @Test
-  void testMultiAllowDuplicates() {
+  @ParameterizedTest
+  @MethodSource("booleanTrueVariants")
+  void testMultiAllowDuplicates(Object trueValue) {
     final String expectedInclude = "<link href=\"/etc/clientlibs/app1/clientlib3.min.css\" rel=\"stylesheet\" type=\"text/css\">\n"
         + "<link href=\"/etc.clientlibs/app1/clientlibs/clientlib4_proxy.min.css\" rel=\"stylesheet\" type=\"text/css\">\n"
         + "<link href=\"/etc.clientlibs/app1/clientlibs/clientlib5_proxy.min.css\" rel=\"stylesheet\" type=\"text/css\">\n";
 
     context.request().setAttribute("categories", CATEGORIES_MULTIPLE);
-    context.request().setAttribute("allowMultipleIncludes", "true");
+    context.request().setAttribute("allowMultipleIncludes", trueValue);
     CSSInclude underTest = AdaptTo.notNull(context.request(), CSSInclude.class);
     assertEquals(expectedInclude,
         underTest.getInclude());
 
     // include again - should be included again (no duplicates removed)
     context.request().setAttribute("categories", CATEGORIES_MULTIPLE);
-    context.request().setAttribute("allowMultipleIncludes", "true");
+    context.request().setAttribute("allowMultipleIncludes", trueValue);
     underTest = AdaptTo.notNull(context.request(), CSSInclude.class);
     assertEquals(expectedInclude, underTest.getInclude());
   }

--- a/src/test/java/io/wcm/wcm/ui/clientlibs/components/JSIncludeTest.java
+++ b/src/test/java/io/wcm/wcm/ui/clientlibs/components/JSIncludeTest.java
@@ -26,6 +26,8 @@ import static org.mockito.Mockito.when;
 import org.apache.sling.api.resource.PersistenceException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -173,20 +175,21 @@ class JSIncludeTest extends AbstractIncludeTest {
         underTest.getInclude());
   }
 
-  @Test
-  void testMultiAllowDuplicates() {
+  @ParameterizedTest
+  @MethodSource("booleanTrueVariants")
+  void testMultiAllowDuplicates(Object trueValue) {
     final String expectedInclude = "<script src=\"/etc/clientlibs/app1/clientlib3.min.js\"></script>\n"
         + "<script src=\"/etc.clientlibs/app1/clientlibs/clientlib4_proxy.min.js\"></script>\n"
         + "<script src=\"/etc.clientlibs/app1/clientlibs/clientlib5_proxy.min.js\"></script>\n";
 
     context.request().setAttribute("categories", CATEGORIES_MULTIPLE);
-    context.request().setAttribute("allowMultipleIncludes", "true");
+    context.request().setAttribute("allowMultipleIncludes", trueValue);
     JSInclude underTest = AdaptTo.notNull(context.request(), JSInclude.class);
     assertEquals(expectedInclude, underTest.getInclude());
 
     // include again - should be included again (no duplicates removed)
     context.request().setAttribute("categories", CATEGORIES_MULTIPLE);
-    context.request().setAttribute("allowMultipleIncludes", "true");
+    context.request().setAttribute("allowMultipleIncludes", trueValue);
     underTest = AdaptTo.notNull(context.request(), JSInclude.class);
     assertEquals(expectedInclude, underTest.getInclude());
   }

--- a/src/test/java/io/wcm/wcm/ui/clientlibs/components/JSIncludeTest.java
+++ b/src/test/java/io/wcm/wcm/ui/clientlibs/components/JSIncludeTest.java
@@ -173,4 +173,22 @@ class JSIncludeTest extends AbstractIncludeTest {
         underTest.getInclude());
   }
 
+  @Test
+  void testMultiAllowDuplicates() {
+    final String expectedInclude = "<script src=\"/etc/clientlibs/app1/clientlib3.min.js\"></script>\n"
+        + "<script src=\"/etc.clientlibs/app1/clientlibs/clientlib4_proxy.min.js\"></script>\n"
+        + "<script src=\"/etc.clientlibs/app1/clientlibs/clientlib5_proxy.min.js\"></script>\n";
+
+    context.request().setAttribute("categories", CATEGORIES_MULTIPLE);
+    context.request().setAttribute("allowMultipleIncludes", "true");
+    JSInclude underTest = AdaptTo.notNull(context.request(), JSInclude.class);
+    assertEquals(expectedInclude, underTest.getInclude());
+
+    // include again - should be included again (no duplicates removed)
+    context.request().setAttribute("categories", CATEGORIES_MULTIPLE);
+    context.request().setAttribute("allowMultipleIncludes", "true");
+    underTest = AdaptTo.notNull(context.request(), JSInclude.class);
+    assertEquals(expectedInclude, underTest.getInclude());
+  }
+
 }

--- a/src/test/java/io/wcm/wcm/ui/clientlibs/components/JSIncludeTest.java
+++ b/src/test/java/io/wcm/wcm/ui/clientlibs/components/JSIncludeTest.java
@@ -46,6 +46,14 @@ class JSIncludeTest extends AbstractIncludeTest {
   }
 
   @Test
+  void testSingleNoAttributes_ContextPath() {
+    context.request().setContextPath("/mycontext");
+    context.request().setAttribute("categories", CATEGORY_SINGLE);
+    JSInclude underTest = AdaptTo.notNull(context.request(), JSInclude.class);
+    assertEquals("<script src=\"/mycontext/etc/clientlibs/app1/clientlib1.min.js\"></script>\n", underTest.getInclude());
+  }
+
+  @Test
   void testSingleNoAttributesUnminified() {
     when(htmlLibraryManager.isMinifyEnabled()).thenReturn(false);
     context.request().setAttribute("categories", CATEGORY_SINGLE);
@@ -141,6 +149,27 @@ class JSIncludeTest extends AbstractIncludeTest {
             + "src=\"/etc.clientlibs/app1/clientlibs/clientlib4_proxy.min.js\" type=\"text/javascript\"></script>\n"
             + "<script async attr1=\"value1\" attr3 data-attr2=\"5\" nomodule "
             + "src=\"/etc.clientlibs/app1/clientlibs/clientlib5_proxy.min.js\" type=\"text/javascript\"></script>\n",
+        underTest.getInclude());
+  }
+
+  @Test
+  void testMultiIgnoreDuplicates() {
+    context.request().setAttribute("categories", CATEGORIES_MULTIPLE);
+    JSInclude underTest = AdaptTo.notNull(context.request(), JSInclude.class);
+    assertEquals("<script src=\"/etc/clientlibs/app1/clientlib3.min.js\"></script>\n"
+        + "<script src=\"/etc.clientlibs/app1/clientlibs/clientlib4_proxy.min.js\"></script>\n"
+        + "<script src=\"/etc.clientlibs/app1/clientlibs/clientlib5_proxy.min.js\"></script>\n",
+        underTest.getInclude());
+
+    // include again - should not include anything
+    context.request().setAttribute("categories", CATEGORIES_MULTIPLE);
+    underTest = AdaptTo.notNull(context.request(), JSInclude.class);
+    assertEquals("", underTest.getInclude());
+
+    // include something different - should include again
+    context.request().setAttribute("categories", CATEGORY_SINGLE);
+    underTest = AdaptTo.notNull(context.request(), JSInclude.class);
+    assertEquals("<script src=\"/etc/clientlibs/app1/clientlib1.min.js\"></script>\n",
         underTest.getInclude());
   }
 


### PR DESCRIPTION
Do not include JS/CSS client libraries twice if the same library is requested multiple times within one request.
This new behavior can be disabled by setting `allowMultipleIncludes=true`.

Fixes https://wcm-io.atlassian.net/browse/WWCM-18